### PR TITLE
Bugfix/account errors

### DIFF
--- a/tastyworks/account_streamer.py
+++ b/tastyworks/account_streamer.py
@@ -41,11 +41,13 @@ class AccountStreamer(object):
         #await self.connection.recv()
 
     def __get_action_msg(self, action, value=None, request_id=None) -> List:
-        msg = {"action":action }
+        msg = {
+            "action": action,
+            "request-id": request_id,
+            "auth-token": self.tasty_session.session_token,
+        }
         if value:
             msg["value"] = value
-        if request_id:
-            msg["request-id"] = request_id
 
         return json.dumps(msg)
 
@@ -53,9 +55,7 @@ class AccountStreamer(object):
         return self.__get_action_msg('account-subscribe', accounts, request_id)
 
     def _get_heartbeat_msg(self) -> List:
-        msg = self.__get_action_msg('heartbeat')
-        msg["auth-token"] = self.tasty_session.session_token
-        return msg
+        return self.__get_action_msg('heartbeat')
 
     async def _consumer(self, message):
         msg_object = json.loads(message)
@@ -105,7 +105,7 @@ class AccountStreamer(object):
         while True:
             LOGGER.debug('Sending keep-alive message')
             await self._send_msg(self._get_heartbeat_msg())
-            await asyncio.sleep(period / 1000)
+            await asyncio.sleep(period / 5000)
 
     async def listen(self):
         async for msg in self.connection:

--- a/tastyworks/account_streamer.py
+++ b/tastyworks/account_streamer.py
@@ -41,13 +41,11 @@ class AccountStreamer(object):
         #await self.connection.recv()
 
     def __get_action_msg(self, action, value=None, request_id=None) -> List:
-        msg = {
-                "action":action,
-                "request-id":request_id,
-                "auth-token":self.tasty_session.session_token,
-            }
+        msg = {"action":action }
         if value:
             msg["value"] = value
+        if request_id:
+            msg["request-id"] = request_id
 
         return json.dumps(msg)
 
@@ -55,7 +53,9 @@ class AccountStreamer(object):
         return self.__get_action_msg('account-subscribe', accounts, request_id)
 
     def _get_heartbeat_msg(self) -> List:
-        return self.__get_action_msg('heartbeat')
+        msg = self.__get_action_msg('heartbeat')
+        msg["auth-token"] = self.tasty_session.session_token
+        return msg
 
     async def _consumer(self, message):
         msg_object = json.loads(message)

--- a/tastyworks/example_account_streamer.py
+++ b/tastyworks/example_account_streamer.py
@@ -77,8 +77,7 @@ async def main_loop(session: TastyAPISession, streamer: AccountStreamer):
 
     # Will log out the accounts in use and then create a closing order automatically
     async for item in streamer.listen():
-        #LOGGER.info('Received item: %s' % item)
-
+        #LOGGER.info("Original Received item: %s" % item)
         myclass = AccountEvent.from_dict(item)
         is_account_subscribe = type(myclass) is ActionAccountEvent and myclass.action_enum == ActionAccountEventType.ACCOUNT_SUBSCRIBE
         is_order = type(myclass) is ChangeAccountEvent and myclass.type_enum == ChangeAccountEventType.ORDER

--- a/tastyworks/models/account_event.py
+++ b/tastyworks/models/account_event.py
@@ -49,12 +49,15 @@ class AccountEvent(object):
 
     @classmethod
     def from_dict(cls, input_dict:dict) -> AccountEventType:
+        input_dict = {k.replace("-","_"): v for k,v in input_dict.items()}
         return cls.detect_type(input_dict)(**input_dict)
 
 @dataclass
 class ActionAccountEvent(AccountEvent):
     action: str
     action_enum: ActionAccountEventType = field(init=False, repr=False)
+    request_id: str = None
+    auth_token: str = None
     message: str = None
     value: List[str] = None
 

--- a/tastyworks/models/account_event.py
+++ b/tastyworks/models/account_event.py
@@ -55,7 +55,7 @@ class AccountEvent(object):
 class ActionAccountEvent(AccountEvent):
     action: str
     action_enum: ActionAccountEventType = field(init=False, repr=False)
-    message: str
+    message: str = None
     value: List[str] = None
 
     def __post_init__(self):


### PR DESCRIPTION
Tastyworks added `request_id` and `auth-token` to the account-subscribe event which broke things.

Also, changed keep-alive from 1s to 5s per what I am seeing in production.